### PR TITLE
Add small screen notice

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -11,6 +11,7 @@
       <router-view/>
     </Tile>
     <Dots />
+    <Notice />
   </div>
 </template>
 
@@ -20,6 +21,7 @@ import { mapGetters, mapMutations } from 'vuex';
 
 // @ is an alias to /src
 import Dots from '@/components/Dots.vue';
+import Notice from '@/components/Notice.vue';
 import Tile from '@/components/Tile.vue';
 import Title from '@/components/Title.vue';
 import Workspace from '@/components/Workspace.vue';
@@ -34,6 +36,7 @@ export default {
   },
   components: {
     Dots,
+    Notice,
     Tile,
     Title,
     Workspace,

--- a/src/components/Notice.vue
+++ b/src/components/Notice.vue
@@ -1,0 +1,23 @@
+<template>
+  <div class="notice">
+    This page is not yet designed for small screens or mobile. Please enlarge the window or try on another device.
+  </div>
+</template>
+
+<style lang="scss">
+div.notice {
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  width: 100%;
+  height: 100%;
+  z-index: 2000;
+  background-color: #EE0;
+  font-size: 30px;
+  padding: 20px;
+  @media screen and (min-width: 1100px) {
+    display: none;
+  }
+}
+</style>
+


### PR DESCRIPTION
This simply overlays on the entire page in the case that the window is
too small. Since the page is currently only designed for larger screens

Issue #71 