### PR TITLE
Fix elongate curve and copy curve

### DIFF
--- a/src/shared/moulage/patterns/bodice.js
+++ b/src/shared/moulage/patterns/bodice.js
@@ -1032,7 +1032,7 @@ export function drawFrontDraft(pattern) {
   let rulerCurve = utilities.getEulerPerpendicularWithPointInside(
     front.points["E'"], [front.points.O], [front.points.O, front.points.J], pattern.dimensions, {isLeftHanded: true, styleName: 'guide', maxInsidePointDist: 2}
   );
-  let longRulerCurve = utilities.elongateCurve(rulerCurve, endOfShoulder);
+  let longRulerCurve = utilities.elongateCurve(rulerCurve, {endLength: endOfShoulder});
   let pointEDoublePrime = new Point(
     longRulerCurve.points[longRulerCurve.points.length - 1],
     {name: "E''", instructions: `Establish point E'' ${endOfShoulder} inches from the waistline along the curved ruler.`}
@@ -1147,7 +1147,6 @@ export function drawFrontDraft(pattern) {
   );
   pattern.addStep({
     actions: [
-      pattern.patternPieces.back.curves["L'O"].reverse(),
       sideCurveCalc.curve,
       sideCurveCalc.endPoint,
     ],


### PR DESCRIPTION
Elongate curve eroneously used only distance and not curve length
Copy curve had some issues that originated with reverse and flip
Curve rotation angle was not consistenly preserved
Endpoint angle was sometimes vastly different than angle of the end of
 the curve, this created issues with reverse
Added addCurveEndpointAndRotateToTrue to compensate for reverse issues,
 but it only works with a couple functions, namely getEulerMidpoint

Issue #94 